### PR TITLE
fix: import syntax

### DIFF
--- a/packages/apps-inject/src/index.ts
+++ b/packages/apps-inject/src/index.ts
@@ -5,7 +5,7 @@ import type { Message, MessageTypes, TransportResponseMessage } from '@mimirdev/
 
 import { enable, handleResponse, injectExtension, isValidMessage, sendMessage } from '@mimirdev/apps-sdk';
 
-import packageInfo from '../package.json' assert { type: 'json' };
+import packageInfo from '../package.json' with { type: 'json' };
 
 export function inject() {
   if (self === parent) {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with

Import assertion was removed from Node.js in favour of `with` [import attributes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with).

This caused `Unexpected identifier 'assert'` when I try to run Vitest on code using Mimir.